### PR TITLE
Improved handling of varargs parameters of (root) actions 

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -47,7 +47,7 @@
 				<!-- Disable annotation processing for the main (not test!) compilation phase. -->
 				<executions>
 					<execution>
-						<id>compile</id>
+						<id>default-compile</id>
 						<phase>compile</phase>
 						<goals>
 							<goal>compile</goal>

--- a/processor/src/main/java/com/github/misberner/duzzt/DuzztAction.java
+++ b/processor/src/main/java/com/github/misberner/duzzt/DuzztAction.java
@@ -203,4 +203,17 @@ public class DuzztAction {
 		return parameters;
 	}
 
+	/**
+	 * Checks, if at least one of the parameters of this action has a varargs type.
+	 * @return {@code true}, if one of the parameters of this action has a varargs type, {@code false} otherwise.
+	 */
+	public boolean getHasVarArgsParams() {
+		for (ParameterInfo p : getParameters()) {
+			if (p.isVarArgs()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/processor/src/main/resources/stringtemplates/edsl-source.stg
+++ b/processor/src/main/resources/stringtemplates/edsl-source.stg
@@ -93,7 +93,8 @@ state_transition(spec, trans) ::= <<
 >>
 
 nonterm_transition(spec, trans) ::= <<
-public <generic_params(trans.action.typeParameters)>
+<if(trans.action.hasVarArgsParams)>@SafeVarargs<endif>
+public final <generic_params(trans.action.typeParameters)>
 <state_class_name(spec, trans.successor)> <trans.action.name>(<params(trans.action.parameters)>)<throws_spec(trans.action.thrownTypes)> {
 	<access_impl(spec)>.<trans.action.method.simpleName>(<args(trans.action.parameters)>);
 	return <access_state(spec, trans.successor)>;


### PR DESCRIPTION
This PR adds an additional check on (root) actions for varargs parameters and applies the `@SafeVarargs` annotation if detected.

Previously, potential varargs parameters on these transitions were generated as-is, issuing warnings of the compiler.